### PR TITLE
make reloading time suffix translatable

### DIFF
--- a/src/main/java/io/redspace/irons_artifice/item/GunItem.java
+++ b/src/main/java/io/redspace/irons_artifice/item/GunItem.java
@@ -190,7 +190,7 @@ public class GunItem extends BaseGeoItem {
             // hide fire rate on single shot guns
             statBuilder.accept(Component.translatable("irons_artifice.tooltip.fire_rate", highlightText.apply(fireRate)));
         }
-        statBuilder.accept(Component.translatable("irons_artifice.tooltip.reload_time", highlightText.apply(reloadTime + "s")));
+        statBuilder.accept(Component.translatable("irons_artifice.tooltip.reload_time", highlightText.apply(reloadTime + Component.translatable("irons_artifice.tooltip.reload_time_suffix").getString())));
         statBuilder.accept(Component.translatable("irons_artifice.tooltip.ammo_capacity", highlightText.apply("" + gunProfile.magazineCapacity())));
         builder.accept(Component.translatable("irons_artifice.tooltip.modifier_count",
                         gunProfile.modifierSlots()

--- a/src/main/resources/assets/irons_artifice/lang/en_us.json
+++ b/src/main/resources/assets/irons_artifice/lang/en_us.json
@@ -107,6 +107,7 @@
   "irons_artifice.tooltip.damage": "%s Damage",
   "irons_artifice.tooltip.fire_rate": "%s Fire Rate",
   "irons_artifice.tooltip.reload_time": "%s Reload",
+  "irons_artifice.tooltip.reload_time_suffix": "s",
   "irons_artifice.tooltip.modifier_count": "%s Modifier Slots",
   "irons_artifice.tooltip.modifier_count_keybind_hint": "%s Modifier Slots (Open: [%s])",
   "irons_artifice.tooltip.keybind_hint": "[Open: %s]",


### PR DESCRIPTION
There is currently an issue where the "s" used to denote time is present in all languages ​​and cannot be changed; therefore, I propose removing the hard-coded designation and moving it to the language file.
